### PR TITLE
Add simple frontend and unit tests

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -6,5 +6,7 @@
 </head>
 <body>
     <h1>Hello from AxiomIQ Frontend</h1>
+    <ul id="kus"></ul>
+    <script type="module" src="./src/app.js"></script>
 </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,9 @@
 {
   "name": "axiomiq-frontend",
   "version": "0.1.0",
+  "type": "module",
   "scripts": {
-    "serve": "npx http-server ."
+    "serve": "npx http-server .",
+    "test": "node --test"
   }
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,7 @@
+export async function getKus(fetcher = fetch) {
+  const resp = await fetcher('/api/kus');
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch kus: ${resp.status}`);
+  }
+  return resp.json();
+}

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,0 +1,19 @@
+import { getKus } from './api.js';
+
+export async function loadKus() {
+  try {
+    const kus = await getKus();
+    const list = document.getElementById('kus');
+    if (!list) return;
+    list.innerHTML = '';
+    for (const ku of kus) {
+      const li = document.createElement('li');
+      li.textContent = ku;
+      list.appendChild(li);
+    }
+  } catch (err) {
+    console.error('Failed to load KUs', err);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', loadKus);

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -1,0 +1,20 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { getKus } from '../src/api.js';
+
+test('getKus fetches /api/kus', async () => {
+  let called = false;
+  const fakeFetch = async (url) => {
+    called = true;
+    assert.equal(url, '/api/kus');
+    return { ok: true, json: async () => ['a', 'b'] };
+  };
+  const result = await getKus(fakeFetch);
+  assert.ok(called);
+  assert.deepEqual(result, ['a', 'b']);
+});
+
+test('getKus throws on error response', async () => {
+  const fakeFetch = async () => ({ ok: false, status: 500 });
+  await assert.rejects(getKus(fakeFetch), /500/);
+});


### PR DESCRIPTION
## Summary
- implement a minimal JS frontend
- add API helper and DOM loader
- update HTML to use the new script
- enable `node --test` in package.json
- add unit tests for API helper

## Testing
- `npm test`