### PR TITLE
Implement simple API and frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # AxiomIQ
+
+This repository provides a minimal demonstration of a backend API and a small
+HTML frontend.  The API is implemented with FastAPI and stores data in memory.
+
+## Endpoints
+
+* `POST /auth/login` – obtain an access token
+* `POST /questions` – create a question
+* `POST /models` – create a model
+* `GET /models` – list models
+* `POST /evaluations` – start an evaluation
+* `GET /evaluations/{id}` – fetch evaluation results
+* `GET /evaluations/{id}/status` – fetch evaluation status
+
+The frontend (`frontend/index.html`) contains a few basic forms that exercise
+these endpoints using JavaScript `fetch` calls.

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,7 +9,7 @@ from . import config
 
 app = FastAPI(title="AxiomIQ Backend")
 
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="api/login")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/login")
 
 
 # ---------------------------------------------------------------------------
@@ -114,7 +114,7 @@ def health():
 # ---------------------------------------------------------------------------
 # Authentication
 # ---------------------------------------------------------------------------
-@app.post("/api/login", response_model=Token)
+@app.post("/auth/login", response_model=Token)
 def login(data: LoginRequest):
     if not config.verify_credentials(data.username, data.password):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Incorrect credentials")
@@ -124,7 +124,7 @@ def login(data: LoginRequest):
 # ---------------------------------------------------------------------------
 # Questions endpoints
 # ---------------------------------------------------------------------------
-@app.get("/api/questions", response_model=List[Question])
+@app.get("/questions", response_model=List[Question])
 def list_questions(ku: Optional[str] = None, limit: int = 100, token: str = Depends(require_token)):
     questions = list(_questions.values())
     if ku:
@@ -132,7 +132,7 @@ def list_questions(ku: Optional[str] = None, limit: int = 100, token: str = Depe
     return questions[:limit]
 
 
-@app.post("/api/questions", response_model=Question)
+@app.post("/questions", response_model=Question)
 def create_question(data: QuestionCreate, token: str = Depends(require_token)):
     global _question_id
     question = Question(id=_question_id, **data.dict())
@@ -141,7 +141,7 @@ def create_question(data: QuestionCreate, token: str = Depends(require_token)):
     return question
 
 
-@app.delete("/api/questions/{question_id}")
+@app.delete("/questions/{question_id}")
 def delete_question(question_id: int, token: str = Depends(require_token)):
     if question_id not in _questions:
         raise HTTPException(status_code=404, detail="Question not found")
@@ -152,12 +152,12 @@ def delete_question(question_id: int, token: str = Depends(require_token)):
 # ---------------------------------------------------------------------------
 # Models endpoints
 # ---------------------------------------------------------------------------
-@app.get("/api/models", response_model=List[Model])
+@app.get("/models", response_model=List[Model])
 def list_models(token: str = Depends(require_token)):
     return list(_models.values())
 
 
-@app.post("/api/models", response_model=Model)
+@app.post("/models", response_model=Model)
 def create_model(data: ModelCreate, token: str = Depends(require_token)):
     global _model_id
     model = Model(id=_model_id, status="active", **data.dict())
@@ -166,7 +166,7 @@ def create_model(data: ModelCreate, token: str = Depends(require_token)):
     return model
 
 
-@app.post("/api/models/{model_id}/test")
+@app.post("/models/{model_id}/test")
 def test_model(model_id: int, token: str = Depends(require_token)):
     if model_id not in _models:
         raise HTTPException(status_code=404, detail="Model not found")
@@ -177,7 +177,7 @@ def test_model(model_id: int, token: str = Depends(require_token)):
 # ---------------------------------------------------------------------------
 # Evaluation endpoints
 # ---------------------------------------------------------------------------
-@app.post("/api/evaluations", response_model=Evaluation)
+@app.post("/evaluations", response_model=Evaluation)
 def create_evaluation(data: EvaluationCreate, token: str = Depends(require_token)):
     eval_id = f"ev{len(_evaluations)+1}"
     evaluation = Evaluation(
@@ -191,14 +191,14 @@ def create_evaluation(data: EvaluationCreate, token: str = Depends(require_token
     return evaluation
 
 
-@app.get("/api/evaluations/{evaluation_id}", response_model=Evaluation)
-def get_evaluation(evaluation_id: str, token: str = Depends(require_token)):
+@app.get("/evaluations/{evaluation_id}/status", response_model=Evaluation)
+def get_evaluation_status(evaluation_id: str, token: str = Depends(require_token)):
     if evaluation_id not in _evaluations:
         raise HTTPException(status_code=404, detail="Evaluation not found")
     return _evaluations[evaluation_id]
 
 
-@app.get("/api/evaluations/{evaluation_id}/results", response_model=EvaluationResult)
+@app.get("/evaluations/{evaluation_id}", response_model=EvaluationResult)
 def get_evaluation_results(evaluation_id: str, token: str = Depends(require_token)):
     if evaluation_id not in _evaluation_results:
         raise HTTPException(status_code=404, detail="Evaluation not found")
@@ -208,7 +208,7 @@ def get_evaluation_results(evaluation_id: str, token: str = Depends(require_toke
 # ---------------------------------------------------------------------------
 # Misc endpoints
 # ---------------------------------------------------------------------------
-@app.get("/api/kus", response_model=List[str])
+@app.get("/kus", response_model=List[str])
 def list_kus(token: str = Depends(require_token)):
     return _kus
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,126 @@
     <title>AxiomIQ Frontend</title>
 </head>
 <body>
-    <h1>Hello from AxiomIQ Frontend</h1>
+<h1>AxiomIQ API Demo</h1>
+
+<form id="login-form">
+  <h2>Login</h2>
+  <input id="username" placeholder="Username" />
+  <input id="password" type="password" placeholder="Password" />
+  <button type="submit">Login</button>
+</form>
+<div id="auth-status"></div>
+
+<form id="model-form">
+  <h2>Add Model</h2>
+  <input id="model-name" placeholder="Name" />
+  <input id="model-type" placeholder="Type" />
+  <button type="submit">Add</button>
+</form>
+<ul id="model-list"></ul>
+
+<form id="question-form">
+  <h2>Add Question</h2>
+  <input id="question-text" placeholder="Text" />
+  <input id="question-ku" placeholder="Knowledge Unit" />
+  <input id="question-options" placeholder="Options (comma)" />
+  <input id="question-correct" placeholder="Correct" />
+  <button type="submit">Add</button>
+</form>
+
+<form id="evaluation-form">
+  <h2>Start Evaluation</h2>
+  <input id="model-ids" placeholder="Model IDs (comma)" />
+  <input id="question-count" type="number" placeholder="Question count" />
+  <button type="submit">Start</button>
+</form>
+<div id="evaluation-result"></div>
+
+<script>
+let token = '';
+document.getElementById('login-form').onsubmit = async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+  const res = await fetch('/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    token = data.access_token;
+    document.getElementById('auth-status').innerText = 'Logged in';
+    loadModels();
+  } else {
+    document.getElementById('auth-status').innerText = 'Login failed';
+  }
+};
+
+async function authHeaders() {
+  return { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token };
+}
+
+document.getElementById('model-form').onsubmit = async (e) => {
+  e.preventDefault();
+  const name = document.getElementById('model-name').value;
+  const type = document.getElementById('model-type').value;
+  await fetch('/models', {
+    method: 'POST',
+    headers: await authHeaders(),
+    body: JSON.stringify({ name, type })
+  });
+  loadModels();
+};
+
+async function loadModels() {
+  const res = await fetch('/models', { headers: await authHeaders() });
+  if (res.ok) {
+    const models = await res.json();
+    const list = document.getElementById('model-list');
+    list.innerHTML = '';
+    models.forEach(m => {
+      const li = document.createElement('li');
+      li.textContent = m.name;
+      list.appendChild(li);
+    });
+  }
+}
+
+document.getElementById('question-form').onsubmit = async (e) => {
+  e.preventDefault();
+  const text = document.getElementById('question-text').value;
+  const ku = document.getElementById('question-ku').value;
+  const options = document.getElementById('question-options').value.split(',');
+  const correct = document.getElementById('question-correct').value;
+  await fetch('/questions', {
+    method: 'POST',
+    headers: await authHeaders(),
+    body: JSON.stringify({ text, options, correct, ku })
+  });
+};
+
+document.getElementById('evaluation-form').onsubmit = async (e) => {
+  e.preventDefault();
+  const modelIds = document.getElementById('model-ids').value
+    .split(',').map(v => parseInt(v.trim())).filter(Boolean);
+  const questionCount = parseInt(document.getElementById('question-count').value);
+  const evalRes = await fetch('/evaluations', {
+    method: 'POST',
+    headers: await authHeaders(),
+    body: JSON.stringify({ model_ids: modelIds, question_scope: [], question_count: questionCount, mode: 'auto' })
+  });
+  if (evalRes.ok) {
+    const ev = await evalRes.json();
+    const res = await fetch('/evaluations/' + ev.evaluation_id, {
+      headers: await authHeaders()
+    });
+    if (res.ok) {
+      const result = await res.json();
+      document.getElementById('evaluation-result').innerText = JSON.stringify(result);
+    }
+  }
+};
+</script>
 </body>
 </html>

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -75,7 +75,7 @@ def test_evaluation_flow():
     evaluation = main.create_evaluation(data, token=config.ACCESS_TOKEN)
     assert evaluation.evaluation_id == "ev1"
 
-    fetched = main.get_evaluation(evaluation.evaluation_id, token=config.ACCESS_TOKEN)
+    fetched = main.get_evaluation_status(evaluation.evaluation_id, token=config.ACCESS_TOKEN)
     assert fetched.evaluation_id == evaluation.evaluation_id
 
     results = main.get_evaluation_results(evaluation.evaluation_id, token=config.ACCESS_TOKEN)
@@ -83,7 +83,7 @@ def test_evaluation_flow():
     assert results.questions == []
 
     with pytest.raises(HTTPException) as exc:
-        main.get_evaluation("missing", token=config.ACCESS_TOKEN)
+        main.get_evaluation_status("missing", token=config.ACCESS_TOKEN)
     assert exc.value.status_code == 404
 
     with pytest.raises(HTTPException) as exc:


### PR DESCRIPTION
## Summary
- create REST endpoints under `/auth`, `/models`, `/questions` and `/evaluations`
- add minimal HTML frontend showing how to call the API
- document API routes
- update backend unit tests

## Testing
- `pytest -q` *(fails: `pytest: command not found`)*