### PR TITLE
Add agent architecture implementation

### DIFF
--- a/backend/agents/__init__.py
+++ b/backend/agents/__init__.py
@@ -1,0 +1,131 @@
+"""Agent implementations for EvalForge.
+
+This module defines simple agent classes used to orchestrate model evaluation
+and related tasks.  The goal is to mirror the architecture described in
+``docs/AGENT_ARCHITECTURE.md`` while keeping the implementation lightweight for
+this demo project.
+"""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List
+
+
+@dataclass
+class ModelAgent:
+    """Wrapper around an AI model.
+
+    Parameters
+    ----------
+    model_id: int
+        Unique identifier for the model.
+    name: str
+        Human friendly name.
+    max_retries: int
+        Number of attempts for the ``ask`` call.
+    response_format: str
+        Expected answer format ("letter", etc.).
+    """
+
+    model_id: int
+    name: str
+    max_retries: int = 2
+    response_format: str = "letter"
+
+    def ask(self, question: str, options: Iterable[str]) -> str:
+        """Return an answer to ``question``.
+
+        The demo implementation simply selects the first option.  In a real
+        system this would call an external model API.
+        """
+
+        # The simplistic policy used for testing.
+        return next(iter(options))
+
+
+@dataclass
+class EvaluationAgent:
+    """Orchestrates the evaluation process across models."""
+
+    models: List[ModelAgent]
+    timeout: int = 30
+    mode: str = "peer"
+
+    def evaluate(self, questions: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+        """Run an evaluation over ``questions`` using the configured models."""
+
+        model_stats: Dict[int, Dict[str, Any]] = {
+            m.model_id: {"correct": 0, "total": 0, "name": m.name}
+            for m in self.models
+        }
+        question_results: List[Dict[str, Any]] = []
+
+        for q in questions:
+            q_res = {"id": q["id"], "answers": {}, "correct": q["correct"]}
+            for m in self.models:
+                answer = m.ask(q["text"], q["options"])
+                q_res["answers"][m.model_id] = answer
+                model_stats[m.model_id]["total"] += 1
+                if answer == q["correct"]:
+                    model_stats[m.model_id]["correct"] += 1
+            question_results.append(q_res)
+
+        model_results = []
+        for mid, stats in model_stats.items():
+            total = stats["total"] or 1
+            accuracy = stats["correct"] / total
+            model_results.append(
+                {
+                    "id": mid,
+                    "name": stats["name"],
+                    "correct": stats["correct"],
+                    "total": total,
+                    "accuracy": accuracy,
+                }
+            )
+
+        return {"models": model_results, "questions": question_results}
+
+
+@dataclass
+class QuestionCurationAgent:
+    """Provides basic question review utilities."""
+
+    def review(self, question: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a trivial review result."""
+        return {"id": question.get("id"), "status": "ok"}
+
+
+@dataclass
+class AnalyticsAgent:
+    """Performs simple analytics on evaluation results."""
+
+    enable_anova: bool = True
+    export_format: str = "csv"
+
+    def summary(self, evaluation_result: Dict[str, Any]) -> Dict[str, Any]:
+        models = evaluation_result.get("models", [])
+        average_accuracy = (
+            sum(m["accuracy"] for m in models) / len(models) if models else 0
+        )
+        return {"model_count": len(models), "average_accuracy": average_accuracy}
+
+
+@dataclass
+class BenchmarkAgent:
+    """Runs external benchmarks for a model."""
+
+    def run(self, model: ModelAgent) -> Dict[str, Any]:
+        # Placeholder benchmark run producing a random score
+        return {"model_id": model.model_id, "benchmark_score": random.random()}
+
+
+__all__ = [
+    "ModelAgent",
+    "EvaluationAgent",
+    "QuestionCurationAgent",
+    "AnalyticsAgent",
+    "BenchmarkAgent",
+]

--- a/backend/agents/config.yaml
+++ b/backend/agents/config.yaml
@@ -1,0 +1,10 @@
+agents:
+  evaluation:
+    timeout: 30
+    mode: peer
+  model:
+    max_retries: 2
+    response_format: "letter"
+  analytics:
+    enable_anova: true
+    export_format: "csv"

--- a/backend/agents/config_loader.py
+++ b/backend/agents/config_loader.py
@@ -1,0 +1,54 @@
+"""Lightweight YAML configuration loader for the agent package."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict
+
+DEFAULT_CONFIG = {
+    "evaluation": {"timeout": 30, "mode": "peer"},
+    "model": {"max_retries": 2, "response_format": "letter"},
+    "analytics": {"enable_anova": True, "export_format": "csv"},
+}
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "config.yaml")
+
+
+def _parse_value(raw: str) -> Any:
+    raw = raw.strip()
+    if raw.lower() in {"true", "false"}:
+        return raw.lower() == "true"
+    try:
+        return int(raw)
+    except ValueError:
+        return raw.strip('"')
+
+
+def load_config(path: str = CONFIG_PATH) -> Dict[str, Any]:
+    """Parse the configuration file into a dictionary."""
+
+    if not os.path.exists(path):
+        return DEFAULT_CONFIG.copy()
+
+    data: Dict[str, Any] = {}
+    current = None
+    with open(path, "r") as fh:
+        for line in fh:
+            line = line.rstrip()
+            if not line or line.lstrip().startswith("#"):
+                continue
+            indent = len(line) - len(line.lstrip())
+            key_val = line.strip()
+            if key_val.endswith(":"):
+                key = key_val[:-1]
+                if indent == 0 and key == "agents":
+                    continue  # root section
+                elif indent == 2:
+                    current = key
+                    data[current] = {}
+            else:
+                if current is None:
+                    continue
+                key, val = map(str.strip, key_val.split(":", 1))
+                data[current][key] = _parse_value(val)
+    return {**DEFAULT_CONFIG, **data}

--- a/tests/agents/test_agents.py
+++ b/tests/agents/test_agents.py
@@ -1,0 +1,44 @@
+from backend.agents import (
+    ModelAgent,
+    EvaluationAgent,
+    QuestionCurationAgent,
+    AnalyticsAgent,
+    BenchmarkAgent,
+)
+
+
+def test_model_agent_answer():
+    agent = ModelAgent(model_id=1, name="m1")
+    answer = agent.ask("Q?", ["A", "B"])
+    assert answer == "A"
+
+
+def test_evaluation_agent():
+    m = ModelAgent(model_id=1, name="m1")
+    q = {"id": 1, "text": "Q?", "options": ["A", "B"], "correct": "A"}
+    eval_agent = EvaluationAgent([m])
+    result = eval_agent.evaluate([q])
+    assert result["models"][0]["correct"] == 1
+    assert result["questions"][0]["answers"][1] == "A"
+
+
+def test_question_curation_agent():
+    agent = QuestionCurationAgent()
+    review = agent.review({"id": 1, "text": "Q"})
+    assert review["status"] == "ok"
+
+
+def test_analytics_agent_summary():
+    analytics = AnalyticsAgent()
+    summary = analytics.summary({
+        "models": [{"accuracy": 1.0}, {"accuracy": 0.5}]
+    })
+    assert summary["model_count"] == 2
+    assert summary["average_accuracy"] == 0.75
+
+
+def test_benchmark_agent():
+    benchmark = BenchmarkAgent()
+    m = ModelAgent(model_id=1, name="m1")
+    result = benchmark.run(m)
+    assert result["model_id"] == 1

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -70,7 +70,12 @@ def test_model_lifecycle():
 
 
 def test_evaluation_flow():
-    data = main.EvaluationCreate(model_ids=[], question_scope=[], question_count=1, mode="auto")
+    qdata = main.QuestionCreate(text="Q?", options=["A", "B"], correct="A", ku="Networking")
+    main.create_question(qdata, token=config.ACCESS_TOKEN)
+    mdata = main.ModelCreate(name="m1", type="local")
+    main.create_model(mdata, token=config.ACCESS_TOKEN)
+
+    data = main.EvaluationCreate(model_ids=[1], question_scope=["Networking"], question_count=1, mode="auto")
     evaluation = main.create_evaluation(data, token=config.ACCESS_TOKEN)
     assert evaluation.evaluation_id == "ev1"
 
@@ -78,8 +83,9 @@ def test_evaluation_flow():
     assert fetched.evaluation_id == evaluation.evaluation_id
 
     results = main.get_evaluation_results(evaluation.evaluation_id, token=config.ACCESS_TOKEN)
-    assert results.models == []
-    assert results.questions == []
+    assert results.models[0]["id"] == 1
+    assert len(results.questions) == 1
+
 
     with pytest.raises(HTTPException) as exc:
         main.get_evaluation_status("missing", token=config.ACCESS_TOKEN)


### PR DESCRIPTION
## Summary
- implement agent classes with EvaluationAgent, ModelAgent, QuestionCurationAgent, AnalyticsAgent and BenchmarkAgent
- add configuration loader and sample config
- update backend to use EvaluationAgent when creating evaluations
- extend backend tests for evaluation and add tests for the new agents

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest')*